### PR TITLE
Change number binding to i64

### DIFF
--- a/generate_api.sh
+++ b/generate_api.sh
@@ -44,6 +44,7 @@ openapi-generator generate -g rust \
  -i .generation/consolidated-specs.yml \
  -o . \
  -c openapi-generator-config.yml \
+ --type-mappings number=i64 \
 
 # adding README elements
 cat templates/README.prepend.md README.md > README.consolidated.md

--- a/openapi-generator-config.yml
+++ b/openapi-generator-config.yml
@@ -1,4 +1,4 @@
 packageName: "scaleway_api_rs"
-packageVersion: "0.1.0"
+packageVersion: "0.2.0"
 apiTests: true
 generateAliasAsModel: true

--- a/openapi-generator-config.yml
+++ b/openapi-generator-config.yml
@@ -1,4 +1,4 @@
 packageName: "scaleway_api_rs"
-packageVersion: "0.2.0"
+packageVersion: "0.1.3"
 apiTests: true
 generateAliasAsModel: true


### PR DESCRIPTION
A the moment, openapi number type maps to f32 which leads to json sent to the api with number as 0.0 for example. The scaleway api does not work with float and throw 400 errors, at least for domain API
This PR changes the binding to i64 which leads to proper output.

I just changed the script not pushed all the changes