### PR TITLE
fix: Use u64 instead of i32 for root_volume_size

### DIFF
--- a/src/models/create_pool_request.rs
+++ b/src/models/create_pool_request.rs
@@ -75,7 +75,7 @@ pub struct CreatePoolRequest {
         with = "::serde_with::rust::double_option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub root_volume_size: Option<Option<i32>>,
+    pub root_volume_size: Option<Option<u64>>,
     /// Defines if the public IP should be removed from Nodes. To use this feature, your Cluster must have an attached Private Network set up with a Public Gateway.
     #[serde(rename = "public_ip_disabled", skip_serializing_if = "Option::is_none")]
     pub public_ip_disabled: Option<bool>,

--- a/src/models/scaleway_period_k8s_period_v1_period_create_cluster_request_period_pool_config.rs
+++ b/src/models/scaleway_period_k8s_period_v1_period_create_cluster_request_period_pool_config.rs
@@ -76,7 +76,7 @@ pub struct ScalewayPeriodK8sPeriodV1PeriodCreateClusterRequestPeriodPoolConfig {
         with = "::serde_with::rust::double_option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub root_volume_size: Option<Option<i32>>,
+    pub root_volume_size: Option<Option<u64>>,
     /// Defines if the public IP should be removed from Nodes. To use this feature, your Cluster must have an attached Private Network set up with a Public Gateway.
     #[serde(rename = "public_ip_disabled", skip_serializing_if = "Option::is_none")]
     pub public_ip_disabled: Option<bool>,

--- a/src/models/scaleway_period_k8s_period_v1_period_pool.rs
+++ b/src/models/scaleway_period_k8s_period_v1_period_pool.rs
@@ -93,7 +93,7 @@ pub struct ScalewayPeriodK8sPeriodV1PeriodPool {
         with = "::serde_with::rust::double_option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub root_volume_size: Option<Option<i32>>,
+    pub root_volume_size: Option<Option<u64>>,
     /// Defines if the public IP should be removed from Nodes. To use this feature, your Cluster must have an attached Private Network set up with a Public Gateway.
     #[serde(rename = "public_ip_disabled", skip_serializing_if = "Option::is_none")]
     pub public_ip_disabled: Option<bool>,


### PR DESCRIPTION
This is a quick win to unblock scw deployments engine side. To dig why the rust client is wrongly generated despite correct API spec:
```
root_volume_size:
          type: integer
          description: System volume disk size. (in bytes)
          format: uint64
          nullable: true
```